### PR TITLE
feat: use slices for changing block sizes

### DIFF
--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -1,0 +1,48 @@
+name: Build LibDaisy Examples
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    
+    - name: Install target
+      run: rustup target add thumbv7em-none-eabihf
+
+    - name: Cache cargo registry
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-registry-
+
+    - name: Build examples
+      run: |
+        excluded_examples="sdmmc usb_midi"  # List of examples to exclude
+        for example in $(ls examples/*.rs); do
+          example_name=$(basename $example .rs)
+          if [[ ! " $excluded_examples " =~ " $example_name " ]]; then
+            cargo build --example $example_name
+          else
+            echo "Skipping $example_name"
+          fi
+        done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ panic-halt = "0.2.0"
 panic-itm = { version = "0.4", optional = true  }
 panic-rtt-target = { version = "0.1.2", features = ["cortex-m"], optional = true }
 panic-semihosting = { version = "0.6", optional = true  }
-rtt-target = { version = "0.4.0", optional = true }
+rtt-target = { version = "0.5.0", optional = true }
 stm32-fmc = "0.3.0"
-stm32h7xx-hal = { version = "0.15.1", features = ["stm32h750v","rt","fmc", "xspi", "sdmmc", "sdmmc-fatfs", "usb_hs"] }
+stm32h7xx-hal = { version = "0.16.0", features = ["stm32h750v","rt","fmc", "xspi", "sdmmc", "sdmmc-fatfs", "usb_hs"] }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4"
 micromath = "2"
 panic-halt = "0.2.0"
 panic-itm = { version = "0.4", optional = true  }
-panic-rtt-target = { version = "0.1.2", features = ["cortex-m"], optional = true }
+panic-rtt-target = { version = "0.1.3", optional = true }
 panic-semihosting = { version = "0.6", optional = true  }
 rtt-target = { version = "0.5.0", optional = true }
 stm32-fmc = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ One of:
 ```bash
 cargo embed --features log-rtt --example passthru
 ```
+**note** You will need to specify the board IE `--chip stm32h750v` for the daisy seed, or create an `Embed.toml` that specifies the chip.
 
 ## Build Examples
 

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -6,13 +6,15 @@
 #[rtic::app(device = stm32h7xx_hal::stm32, peripherals = true)]
 mod app {
     use libdaisy::{
-        gpio, hal::gpio::{Edge, ExtiPin}, logger, system
+        gpio,
+        hal::gpio::{Edge, ExtiPin},
+        logger, system,
     };
     use log::info;
 
     #[shared]
     struct Shared {}
-    
+
     #[local]
     struct Local {
         button: gpio::SeedButton,

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -5,7 +5,11 @@
 
 #[rtic::app(device = stm32h7xx_hal::stm32, peripherals = true)]
 mod app {
-    use libdaisy::{gpio, system, hal::gpio::{Edge, ExtiPin}};
+    use libdaisy::{
+        gpio,
+        hal::gpio::{Edge, ExtiPin},
+        system,
+    };
 
     #[shared]
     struct SharedResources {}

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -5,8 +5,7 @@
 
 #[rtic::app(device = stm32h7xx_hal::stm32, peripherals = true)]
 mod app {
-    use libdaisy::{gpio, system};
-    use stm32h7xx_hal::gpio::{Edge, ExtiPin};
+    use libdaisy::{gpio, system, hal::gpio::{Edge, ExtiPin}};
 
     #[shared]
     struct SharedResources {}

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -6,27 +6,27 @@
 #[rtic::app(device = stm32h7xx_hal::stm32, peripherals = true)]
 mod app {
     use libdaisy::{
-        gpio,
-        hal::gpio::{Edge, ExtiPin},
-        system,
+        gpio, hal::gpio::{Edge, ExtiPin}, logger, system
     };
+    use log::info;
 
     #[shared]
-    struct SharedResources {}
+    struct Shared {}
+    
     #[local]
-    struct LocalResources {
+    struct Local {
         button: gpio::SeedButton,
         led: gpio::SeedLed,
     }
 
-    use panic_halt as _;
-
     #[init]
-    fn init(ctx: init::Context) -> (SharedResources, LocalResources, init::Monotonics) {
+    fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
+        logger::init();
         let mut core = ctx.core;
         let mut device = ctx.device;
         let ccdr = system::System::init_clocks(device.PWR, device.RCC, &device.SYSCFG);
         let mut system = libdaisy::system_init!(core, device, ccdr);
+        info!("Startup done!");
 
         // Button
         system.gpio.button.make_interrupt_source(&mut device.SYSCFG);
@@ -37,8 +37,8 @@ mod app {
         system.gpio.button.enable_interrupt(&mut device.EXTI);
 
         (
-            SharedResources {},
-            LocalResources {
+            Shared {},
+            Local {
                 button: system.gpio.button,
                 led: system.gpio.led,
             },

--- a/examples/delay.rs
+++ b/examples/delay.rs
@@ -7,7 +7,7 @@
     peripherals = true,
 )]
 mod app {
-    use libdaisy::{audio, logger, system};
+    use libdaisy::{audio::{self, AudioBuffer}, logger, system};
     use log::info;
 
     #[shared]
@@ -16,7 +16,7 @@ mod app {
     #[local]
     struct Local {
         audio: audio::Audio,
-        buffer: audio::AudioBuffer<{ audio::BLOCK_SIZE_MAX }>,
+        buffer: AudioBuffer,
         sdram: &'static mut [f32],
     }
 
@@ -28,7 +28,7 @@ mod app {
         let device = ctx.device;
         let ccdr = system::System::init_clocks(device.PWR, device.RCC, &device.SYSCFG);
         let system = libdaisy::system_init!(core, device, ccdr);
-        let buffer: audio::AudioBuffer<{ audio::BLOCK_SIZE_MAX }> = audio::AudioBuffer::new();
+        let buffer = [(0.0,0.0);audio::BLOCK_SIZE_MAX];
 
         info!("Startup done!");
 
@@ -61,7 +61,7 @@ mod app {
         let index: &mut usize = ctx.local.index;
 
         if audio.get_stereo(buffer) {
-            for (left, right) in buffer.iter() {
+            for (left, right) in buffer {
                 audio
                     .push_stereo((sdram[*index], sdram[*index + 1]))
                     .unwrap();

--- a/examples/delay.rs
+++ b/examples/delay.rs
@@ -7,7 +7,10 @@
     peripherals = true,
 )]
 mod app {
-    use libdaisy::{audio::{self, AudioBuffer}, logger, system};
+    use libdaisy::{
+        audio::{self, AudioBuffer},
+        logger, system,
+    };
     use log::info;
 
     #[shared]
@@ -28,7 +31,7 @@ mod app {
         let device = ctx.device;
         let ccdr = system::System::init_clocks(device.PWR, device.RCC, &device.SYSCFG);
         let system = libdaisy::system_init!(core, device, ccdr);
-        let buffer = [(0.0,0.0);audio::BLOCK_SIZE_MAX];
+        let buffer = [(0.0, 0.0); audio::BLOCK_SIZE_MAX];
 
         info!("Startup done!");
 

--- a/examples/hid_blinky.rs
+++ b/examples/hid_blinky.rs
@@ -33,7 +33,6 @@ mod app {
         let mut system = libdaisy::system_init!(core, device, ccdr);
         info!("Startup done!");
 
-        //TODO check that this timer is setup correctly
         let mut timer2 = stm32h7xx_hal::timer::TimerExt::timer(
             device.TIM2,
             MilliSeconds::from_ticks(100).into_rate(),

--- a/examples/knob.rs
+++ b/examples/knob.rs
@@ -33,7 +33,7 @@ mod app {
         let ccdr = system::System::init_clocks(device.PWR, device.RCC, &device.SYSCFG);
         let mut system = libdaisy::system_init!(core, device, ccdr);
         info!("Startup done!");
-        //TODO check this
+
         let mut timer2 = stm32h7xx_hal::timer::TimerExt::timer(
             device.TIM2,
             MilliSeconds::from_ticks(100).into_rate(),

--- a/examples/knob.rs
+++ b/examples/knob.rs
@@ -11,6 +11,7 @@ mod app {
     use libdaisy::logger;
     use libdaisy::{gpio::*, hid, prelude::*, system};
     use log::info;
+    use stm32h7xx_hal::time::MilliSeconds;
     use stm32h7xx_hal::{adc, stm32, timer::Timer};
 
     #[shared]
@@ -27,12 +28,25 @@ mod app {
     #[init]
     fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
         logger::init();
-        let mut system = system::System::init(ctx.core, ctx.device);
+        let mut core = ctx.core;
+        let device = ctx.device;
+        let ccdr = system::System::init_clocks(device.PWR, device.RCC, &device.SYSCFG);
+        let mut system = libdaisy::system_init!(core, device, ccdr);
+        info!("Startup done!");
+        //TODO check this
+        let mut timer2 = stm32h7xx_hal::timer::TimerExt::timer(
+            device.TIM2,
+            MilliSeconds::from_ticks(100).into_rate(),
+            ccdr.peripheral.TIM2,
+            &ccdr.clocks,
+        );
+
+        timer2.listen(stm32h7xx_hal::timer::Event::TimeOut);
 
         let duty_cycle = 50;
         let resolution = 20;
 
-        system.timer2.set_freq((duty_cycle * resolution).Hz());
+        timer2.set_freq((duty_cycle * resolution).Hz());
 
         let daisy28 = system
             .gpio
@@ -62,7 +76,7 @@ mod app {
                 led1,
                 adc1,
                 control1,
-                timer2: system.timer2,
+                timer2,
             },
             init::Monotonics(),
         )

--- a/examples/passthru.rs
+++ b/examples/passthru.rs
@@ -6,7 +6,7 @@
     peripherals = true,
 )]
 mod app {
-    const BLOCK_SIZE: usize = 48;
+    const BLOCK_SIZE: usize = 128;
     use libdaisy::logger;
     use libdaisy::{audio, system};
     use log::info;
@@ -62,7 +62,7 @@ mod app {
         let buffer = ctx.local.buffer;
 
         if audio.get_stereo(buffer) {
-            for (left, right) in &buffer.as_slice()[..BLOCK_SIZE / 2] {
+            for (left, right) in &buffer.as_slice()[..BLOCK_SIZE ] {
                 let _ = audio.push_stereo((*left, *right));
             }
         } else {

--- a/examples/passthru.rs
+++ b/examples/passthru.rs
@@ -6,7 +6,7 @@
     peripherals = true,
 )]
 mod app {
-    const BLOCK_SIZE:usize = 48;
+    const BLOCK_SIZE: usize = 48;
     use libdaisy::logger;
     use libdaisy::{audio, system};
     use log::info;

--- a/examples/passthru.rs
+++ b/examples/passthru.rs
@@ -17,7 +17,7 @@ mod app {
     #[local]
     struct Local {
         audio: audio::Audio,
-        buffer: [(f32, f32); BLOCK_SIZE],
+        buffer: audio::AudioBuffer,
     }
 
     #[init]
@@ -32,7 +32,7 @@ mod app {
         let ccdr = system::System::init_clocks(device.PWR, device.RCC, &device.SYSCFG);
         let system = libdaisy::system_init!(core, device, ccdr, BLOCK_SIZE);
 
-        let buffer = [(0.0, 0.0); BLOCK_SIZE];
+        let buffer = [(0.0, 0.0); audio::BLOCK_SIZE_MAX];
 
         info!("Startup done!!");
 
@@ -62,7 +62,7 @@ mod app {
         let buffer = ctx.local.buffer;
 
         if audio.get_stereo(buffer) {
-            for (left, right) in buffer {
+            for (left, right) in &buffer.as_slice()[..BLOCK_SIZE / 2] {
                 let _ = audio.push_stereo((*left, *right));
             }
         } else {

--- a/examples/passthru.rs
+++ b/examples/passthru.rs
@@ -62,7 +62,7 @@ mod app {
         let buffer = ctx.local.buffer;
 
         if audio.get_stereo(buffer) {
-            for (left, right) in &buffer.as_slice()[..BLOCK_SIZE ] {
+            for (left, right) in &buffer.as_slice()[..BLOCK_SIZE] {
                 let _ = audio.push_stereo((*left, *right));
             }
         } else {

--- a/examples/passthru.rs
+++ b/examples/passthru.rs
@@ -6,7 +6,7 @@
     peripherals = true,
 )]
 mod app {
-    use libdaisy::audio::AudioBuffer;
+    const BLOCK_SIZE:usize = 48;
     use libdaisy::logger;
     use libdaisy::{audio, system};
     use log::info;
@@ -17,7 +17,7 @@ mod app {
     #[local]
     struct Local {
         audio: audio::Audio,
-        buffer: audio::AudioBuffer<{ audio::BLOCK_SIZE_MAX }>,
+        buffer: [(f32, f32); BLOCK_SIZE],
     }
 
     #[init]
@@ -30,9 +30,9 @@ mod app {
         let mut core = ctx.core;
         let device = ctx.device;
         let ccdr = system::System::init_clocks(device.PWR, device.RCC, &device.SYSCFG);
-        let system = libdaisy::system_init!(core, device, ccdr);
+        let system = libdaisy::system_init!(core, device, ccdr, BLOCK_SIZE);
 
-        let buffer: AudioBuffer<{ audio::BLOCK_SIZE_MAX }> = AudioBuffer::new();
+        let buffer = [(0.0, 0.0); BLOCK_SIZE];
 
         info!("Startup done!!");
 
@@ -62,7 +62,7 @@ mod app {
         let buffer = ctx.local.buffer;
 
         if audio.get_stereo(buffer) {
-            for (left, right) in buffer.iter() {
+            for (left, right) in buffer {
                 let _ = audio.push_stereo((*left, *right));
             }
         } else {

--- a/examples/sdram.rs
+++ b/examples/sdram.rs
@@ -26,11 +26,20 @@ mod app {
     #[init]
     fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
         logger::init();
-        let mut system = system::System::init(ctx.core, ctx.device);
+        let mut core = ctx.core;
+        let device = ctx.device;
+        let ccdr = system::System::init_clocks(device.PWR, device.RCC, &device.SYSCFG);
+        let system = libdaisy::system_init!(core, device, ccdr);
+        info!("Startup done!");
+        let mut timer2 = stm32h7xx_hal::timer::TimerExt::timer(
+            device.TIM2,
+            MilliSeconds::from_ticks(100).into_rate(),
+            ccdr.peripheral.TIM2,
+            &ccdr.clocks,
+        );
+        timer2.listen(stm32h7xx_hal::timer::Event::TimeOut);
 
-        system
-            .timer2
-            .set_freq(MilliSeconds::from_ticks(500).into_rate());
+        timer2.set_freq(MilliSeconds::from_ticks(500).into_rate());
 
         let sdram = system.sdram;
 
@@ -72,7 +81,7 @@ mod app {
             Shared {},
             Local {
                 seed_led: system.gpio.led,
-                timer2: system.timer2,
+                timer2,
             },
             init::Monotonics(),
         )

--- a/examples/sine.rs
+++ b/examples/sine.rs
@@ -7,13 +7,13 @@
     peripherals = true
 )]
 mod app {
-    use libdaisy::{audio, gpio::SeedLed, logger, system};
+    use libdaisy::{audio::{self, AudioBuffer}, gpio::SeedLed, logger, system};
     use libm;
     use log::info;
 
     pub struct AudioRate {
         pub audio: audio::Audio,
-        buffer: audio::AudioBuffer<{ audio::BLOCK_SIZE_MAX }>,
+        buffer: AudioBuffer,
     }
 
     #[shared]
@@ -35,7 +35,7 @@ mod app {
         let ccdr = system::System::init_clocks(device.PWR, device.RCC, &device.SYSCFG);
         let system = libdaisy::system_init!(core, device, ccdr);
         info!("Startup done!");
-        let buffer: audio::AudioBuffer<{ audio::BLOCK_SIZE_MAX }> = audio::AudioBuffer::new();
+        let buffer = [(0.0,0.0);audio::BLOCK_SIZE_MAX];
 
         (
             Shared {},
@@ -69,7 +69,7 @@ mod app {
         let led = ctx.local.led;
 
         audio.get_stereo(buffer);
-        for _ in 0..buffer.iter().len() {
+        for _ in 0..buffer.len() {
             // phase is gonna get bigger and bigger
             // at some point floating point errors will quantize the pitch
             *phase += *pitch / libdaisy::AUDIO_SAMPLE_RATE as f32;

--- a/examples/sine.rs
+++ b/examples/sine.rs
@@ -7,14 +7,13 @@
     peripherals = true
 )]
 mod app {
-    use libdaisy::{audio, logger, system};
+    use libdaisy::{audio, gpio::SeedLed, logger, system};
     use libm;
     use log::info;
-    use stm32h7xx_hal::time::MilliSeconds;
 
     pub struct AudioRate {
         pub audio: audio::Audio,
-        pub buffer: audio::AudioBuffer,
+        buffer: audio::AudioBuffer<{ audio::BLOCK_SIZE_MAX }>,
     }
 
     #[shared]
@@ -25,19 +24,18 @@ mod app {
         ar: AudioRate,
         phase: f32,
         pitch: f32,
+        led: SeedLed,
     }
 
     #[init]
     fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
         logger::init();
-        let mut system = system::System::init(ctx.core, ctx.device);
+        let mut core = ctx.core;
+        let device = ctx.device;
+        let ccdr = system::System::init_clocks(device.PWR, device.RCC, &device.SYSCFG);
+        let system = libdaisy::system_init!(core, device, ccdr);
         info!("Startup done!");
-
-        system
-            .timer2
-            .set_freq(MilliSeconds::from_ticks(500).into_rate());
-
-        let buffer = [(0.0, 0.0); audio::BLOCK_SIZE_MAX]; // audio ring buffer
+        let buffer: audio::AudioBuffer<{ audio::BLOCK_SIZE_MAX }> = audio::AudioBuffer::new();
 
         (
             Shared {},
@@ -48,6 +46,7 @@ mod app {
                 },
                 phase: 0.0,
                 pitch: 440.0,
+                led: system.gpio.led,
             },
             init::Monotonics(),
         )
@@ -61,15 +60,16 @@ mod app {
     }
 
     // Interrupt handler for audio
-    #[task(binds = DMA1_STR1, local = [ar, phase, pitch], shared = [], priority = 8)]
+    #[task(binds = DMA1_STR1, local = [ar, phase, pitch, led], shared = [], priority = 8)]
     fn audio_handler(ctx: audio_handler::Context) {
         let audio = &mut ctx.local.ar.audio;
         let buffer = &mut ctx.local.ar.buffer;
         let phase = ctx.local.phase;
         let pitch = ctx.local.pitch;
+        let led = ctx.local.led;
 
         audio.get_stereo(buffer);
-        for _ in 0..buffer.len() {
+        for _ in 0..buffer.iter().len() {
             // phase is gonna get bigger and bigger
             // at some point floating point errors will quantize the pitch
             *phase += *pitch / libdaisy::AUDIO_SAMPLE_RATE as f32;
@@ -78,6 +78,7 @@ mod app {
 
             if *pitch > 10_000.0 {
                 *pitch = 440.0;
+                led.toggle();
             }
 
             *pitch += 0.1;

--- a/examples/sine.rs
+++ b/examples/sine.rs
@@ -7,7 +7,11 @@
     peripherals = true
 )]
 mod app {
-    use libdaisy::{audio::{self, AudioBuffer}, gpio::SeedLed, logger, system};
+    use libdaisy::{
+        audio::{self, AudioBuffer},
+        gpio::SeedLed,
+        logger, system,
+    };
     use libm;
     use log::info;
 
@@ -35,7 +39,7 @@ mod app {
         let ccdr = system::System::init_clocks(device.PWR, device.RCC, &device.SYSCFG);
         let system = libdaisy::system_init!(core, device, ccdr);
         info!("Startup done!");
-        let buffer = [(0.0,0.0);audio::BLOCK_SIZE_MAX];
+        let buffer = [(0.0, 0.0); audio::BLOCK_SIZE_MAX];
 
         (
             Shared {},

--- a/examples/switch.rs
+++ b/examples/switch.rs
@@ -26,7 +26,17 @@ mod app {
     #[init]
     fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
         logger::init();
-        let mut system = system::System::init(ctx.core, ctx.device);
+        let mut core = ctx.core;
+        let device = ctx.device;
+        let ccdr = system::System::init_clocks(device.PWR, device.RCC, &device.SYSCFG);
+        let mut system = libdaisy::system_init!(core, device, ccdr);
+        info!("Startup done!");
+        let mut timer2 = stm32h7xx_hal::timer::TimerExt::timer(
+            device.TIM2,
+            MilliSeconds::from_ticks(100).into_rate(),
+            ccdr.peripheral.TIM2,
+            &ccdr.clocks,
+        );
 
         let daisy28 = system
             .gpio
@@ -35,9 +45,7 @@ mod app {
             .expect("Failed to get pin daisy28!")
             .into_pull_up_input();
 
-        system
-            .timer2
-            .set_freq(MilliSeconds::from_ticks(1).into_rate());
+        timer2.set_freq(MilliSeconds::from_ticks(1).into_rate());
 
         // Switch rate is determined by timer freq
         let mut switch1 = hid::Switch::new(daisy28, hid::SwitchType::PullUp);
@@ -49,7 +57,7 @@ mod app {
             Local {
                 seed_led: system.gpio.led,
                 switch1,
-                timer2: system.timer2,
+                timer2,
             },
             init::Monotonics(),
         )

--- a/examples/volume.rs
+++ b/examples/volume.rs
@@ -35,7 +35,7 @@ mod app {
         let device = ctx.device;
         let ccdr = system::System::init_clocks(device.PWR, device.RCC, &device.SYSCFG);
         let mut system = libdaisy::system_init!(core, device, ccdr);
-        let buffer = [(0.0,0.0);audio::BLOCK_SIZE_MAX];
+        let buffer = [(0.0, 0.0); audio::BLOCK_SIZE_MAX];
 
         info!("Enable adc1");
         let mut adc1 = system.adc1.enable();

--- a/examples/volume.rs
+++ b/examples/volume.rs
@@ -53,7 +53,6 @@ mod app {
         // Transform linear input into logarithmic
         control1.set_transform(|x| x * x);
 
-        //TODO check if timer is correct
         let timer2 = stm32h7xx_hal::timer::TimerExt::timer(
             device.TIM2,
             MilliSeconds::from_ticks(100).into_rate(),

--- a/examples/volume.rs
+++ b/examples/volume.rs
@@ -12,7 +12,7 @@ mod app {
 
     use libdaisy::{audio, gpio::*, hid, logger, prelude::*, system, MILICYCLES};
     use log::info;
-    use stm32h7xx_hal::{adc, stm32, timer::Timer};
+    use stm32h7xx_hal::{adc, stm32, time::MilliSeconds, timer::Timer};
 
     #[shared]
     struct Shared {
@@ -22,7 +22,7 @@ mod app {
     #[local]
     struct Local {
         audio: audio::Audio,
-        buffer: audio::AudioBuffer,
+        buffer: audio::AudioBuffer<{ audio::BLOCK_SIZE_MAX }>,
         adc1: adc::Adc<stm32::ADC1, adc::Enabled>,
         timer2: Timer<stm32::TIM2>,
     }
@@ -30,8 +30,11 @@ mod app {
     #[init]
     fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
         logger::init();
-        let mut system = system::System::init(ctx.core, ctx.device);
-        let buffer = [(0.0, 0.0); audio::BLOCK_SIZE_MAX];
+        let mut core = ctx.core;
+        let device = ctx.device;
+        let ccdr = system::System::init_clocks(device.PWR, device.RCC, &device.SYSCFG);
+        let mut system = libdaisy::system_init!(core, device, ccdr);
+        let buffer: audio::AudioBuffer<{ audio::BLOCK_SIZE_MAX }> = audio::AudioBuffer::new();
 
         info!("Enable adc1");
         let mut adc1 = system.adc1.enable();
@@ -49,13 +52,21 @@ mod app {
         // Transform linear input into logarithmic
         control1.set_transform(|x| x * x);
 
+        //TODO check if timer is correct
+        let timer2 = stm32h7xx_hal::timer::TimerExt::timer(
+            device.TIM2,
+            MilliSeconds::from_ticks(100).into_rate(),
+            ccdr.peripheral.TIM2,
+            &ccdr.clocks,
+        );
+
         (
             Shared { control1 },
             Local {
                 audio: system.audio,
                 buffer,
                 adc1,
-                timer2: system.timer2,
+                timer2,
             },
             init::Monotonics(),
         )
@@ -76,7 +87,7 @@ mod app {
         let audio_handler::LocalResources { audio, buffer } = ctx.local;
 
         if audio.get_stereo(buffer) {
-            for (left, right) in buffer {
+            for (left, right) in buffer.iter_mut() {
                 ctx.shared.control1.lock(|c| {
                     let volume = c.get_value();
                     info!("{}", volume);

--- a/examples/volume.rs
+++ b/examples/volume.rs
@@ -10,6 +10,7 @@
 mod app {
     //use rtic::cyccnt::U32Ext;
 
+    use audio::AudioBuffer;
     use libdaisy::{audio, gpio::*, hid, logger, prelude::*, system, MILICYCLES};
     use log::info;
     use stm32h7xx_hal::{adc, stm32, time::MilliSeconds, timer::Timer};
@@ -22,7 +23,7 @@ mod app {
     #[local]
     struct Local {
         audio: audio::Audio,
-        buffer: audio::AudioBuffer<{ audio::BLOCK_SIZE_MAX }>,
+        buffer: AudioBuffer,
         adc1: adc::Adc<stm32::ADC1, adc::Enabled>,
         timer2: Timer<stm32::TIM2>,
     }
@@ -34,7 +35,7 @@ mod app {
         let device = ctx.device;
         let ccdr = system::System::init_clocks(device.PWR, device.RCC, &device.SYSCFG);
         let mut system = libdaisy::system_init!(core, device, ccdr);
-        let buffer: audio::AudioBuffer<{ audio::BLOCK_SIZE_MAX }> = audio::AudioBuffer::new();
+        let buffer = [(0.0,0.0);audio::BLOCK_SIZE_MAX];
 
         info!("Enable adc1");
         let mut adc1 = system.adc1.enable();

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -128,9 +128,19 @@ impl From<f32> for S24 {
 
 impl From<S24> for f32 {
     fn from(x: S24) -> f32 {
-        ((x.0 ^ S24_SIGN) - S24_SIGN) as f32 * S24_TO_F32_SCALE
+        // Extract the sign bit and the magnitude
+        let sign_bit = x.0 & S24_SIGN;
+        let magnitude = x.0 & !S24_SIGN;
+
+        // Convert the magnitude to f32 and apply the sign
+        if sign_bit == 0 {
+            magnitude as f32 * S24_TO_F32_SCALE
+        } else {
+            -(magnitude as f32 * S24_TO_F32_SCALE)
+        }
     }
 }
+
 
 /// Core struct for handling audio I/O
 pub struct Audio {

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -39,7 +39,35 @@ const S24_SIGN: i32 = 0x800000;
 /// Largest number of audio blocks for a single DMA operation
 pub const MAX_TRANSFER_SIZE: usize = BLOCK_SIZE_MAX * 2;
 
-pub type AudioBuffer = [(f32, f32); BLOCK_SIZE_MAX];
+pub struct AudioBuffer<const SIZE: usize> {
+    data: [(f32, f32); SIZE],
+}
+
+impl Default for AudioBuffer<BLOCK_SIZE_MAX> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const SIZE: usize> AudioBuffer<SIZE> {
+    pub fn new() -> Self {
+        Self {
+            data: [(0.0, 0.0); SIZE],
+        }
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [(f32, f32)] {
+        &mut self.data
+    }
+
+    pub fn iter(&self) -> core::slice::Iter<'_, (f32, f32)> {
+        self.data.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, (f32, f32)> {
+        self.data.iter_mut()
+    }
+}
 
 type DmaInputStream = dma::Transfer<
     dma::dma::Stream1<stm32::DMA1>,
@@ -443,14 +471,14 @@ impl Audio {
     }
 
     /// Gets the audio input from the DMA memory and writes it to buffer
-    pub fn get_stereo(&mut self, buffer: &mut AudioBuffer) -> bool {
+    pub fn get_stereo<const SIZE: usize>(&mut self, buffer: &mut AudioBuffer<SIZE>) -> bool {
         if self.read() {
             for (i, (left, right)) in StereoIterator::new(
                 &self.input.buffer[self.input.index..self.input.index + MAX_TRANSFER_SIZE],
             )
             .enumerate()
             {
-                buffer[i] = (left, right);
+                buffer.as_mut_slice()[i] = (left, right);
             }
             true
         } else {

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -172,7 +172,7 @@ impl Audio {
         match board_version {
             crate::system::Version::Seed | crate::system::Version::Seed1_1 => {
                 let rx_buffer: &'static mut [u32] =
-                    unsafe { &mut RX_BUFFER.as_mut_slice()[..block_size* 2 * 2] };
+                    unsafe { &mut RX_BUFFER.as_mut_slice()[..block_size * 2 * 2] };
                 let dma_config = dma::dma::DmaConfig::default()
                     .priority(dma::config::Priority::High)
                     .memory_increment(true)
@@ -188,7 +188,7 @@ impl Audio {
                 );
 
                 let tx_buffer: &'static mut [u32] =
-                    unsafe { &mut TX_BUFFER.as_mut_slice()[..block_size* 2 * 2] };
+                    unsafe { &mut TX_BUFFER.as_mut_slice()[..block_size * 2 * 2] };
                 let dma_config = dma_config
                     .transfer_complete_interrupt(true)
                     .half_transfer_interrupt(true);
@@ -472,7 +472,7 @@ impl Audio {
     fn get_stereo_iter(&mut self) -> Option<StereoIterator> {
         if self.read() {
             return Some(StereoIterator::new(
-                &self.input.buffer[self.input.index..self.input.index + self.max_transfer_size]
+                &self.input.buffer[self.input.index..self.input.index + self.max_transfer_size],
             ));
         }
         None

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -171,8 +171,9 @@ impl Audio {
     ) -> Self {
         match board_version {
             crate::system::Version::Seed | crate::system::Version::Seed1_1 => {
+                let dma_buffer_size = block_size * 2 * 2;
                 let rx_buffer: &'static mut [u32] =
-                    unsafe { &mut RX_BUFFER.as_mut_slice()[..block_size * 2 * 2] };
+                    unsafe { &mut RX_BUFFER.as_mut_slice()[..dma_buffer_size] };
                 let dma_config = dma::dma::DmaConfig::default()
                     .priority(dma::config::Priority::High)
                     .memory_increment(true)
@@ -188,7 +189,7 @@ impl Audio {
                 );
 
                 let tx_buffer: &'static mut [u32] =
-                    unsafe { &mut TX_BUFFER.as_mut_slice()[..block_size * 2 * 2] };
+                    unsafe { &mut TX_BUFFER.as_mut_slice()[..dma_buffer_size] };
                 let dma_config = dma_config
                     .transfer_complete_interrupt(true)
                     .half_transfer_interrupt(true);
@@ -304,8 +305,9 @@ impl Audio {
                 }
             }
             crate::system::Version::Seed2DFM => {
+                let dma_buffer_size = block_size * 2 * 2;
                 let rx_buffer: &'static mut [u32] =
-                    unsafe { &mut RX_BUFFER.as_mut_slice()[..block_size] };
+                    unsafe { &mut RX_BUFFER.as_mut_slice()[..dma_buffer_size] };
                 let dma_config = dma::dma::DmaConfig::default()
                     .priority(dma::config::Priority::High)
                     .memory_increment(true)
@@ -321,7 +323,7 @@ impl Audio {
                 );
 
                 let tx_buffer: &'static mut [u32] =
-                    unsafe { &mut TX_BUFFER.as_mut_slice()[..block_size] };
+                    unsafe { &mut TX_BUFFER.as_mut_slice()[..dma_buffer_size] };
                 let dma_config = dma_config
                     .transfer_complete_interrupt(true)
                     .half_transfer_interrupt(true);

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -299,7 +299,7 @@ impl Audio {
                 }
             }
             crate::system::Version::Seed2DFM => {
-                let rx_buffer: &'static mut [u32] = unsafe { &mut RX_BUFFER };
+                let rx_buffer: &'static mut [u32] = unsafe { &mut RX_BUFFER.as_mut_slice()[..block_size] };
                 let dma_config = dma::dma::DmaConfig::default()
                     .priority(dma::config::Priority::High)
                     .memory_increment(true)
@@ -314,7 +314,7 @@ impl Audio {
                     dma_config,
                 );
 
-                let tx_buffer: &'static mut [u32] = unsafe { &mut TX_BUFFER };
+                let tx_buffer: &'static mut [u32] = unsafe { &mut TX_BUFFER.as_mut_slice()[..block_size] };
                 let dma_config = dma_config
                     .transfer_complete_interrupt(true)
                     .half_transfer_interrupt(true);
@@ -445,7 +445,7 @@ impl Audio {
     }
 
     /// Gets the audio input from the DMA memory and writes it to buffer
-    pub fn get_stereo(&mut self, buffer: &mut [(f32, f32)]) -> bool {
+    pub fn get_stereo(&mut self, buffer: &mut AudioBuffer) -> bool {
         if self.read() {
             for (i, (left, right)) in StereoIterator::new(
                 &self.input.buffer[self.input.index..self.input.index + MAX_TRANSFER_SIZE],

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -128,11 +128,9 @@ impl From<f32> for S24 {
 
 impl From<S24> for f32 {
     fn from(x: S24) -> f32 {
-        // Extract the sign bit and the magnitude
         let sign_bit = x.0 & S24_SIGN;
         let magnitude = x.0 & !S24_SIGN;
 
-        // Convert the magnitude to f32 and apply the sign
         if sign_bit == 0 {
             magnitude as f32 * S24_TO_F32_SCALE
         } else {
@@ -140,7 +138,6 @@ impl From<S24> for f32 {
         }
     }
 }
-
 
 /// Core struct for handling audio I/O
 pub struct Audio {

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -172,7 +172,7 @@ impl Audio {
         match board_version {
             crate::system::Version::Seed | crate::system::Version::Seed1_1 => {
                 let rx_buffer: &'static mut [u32] =
-                    unsafe { &mut RX_BUFFER.as_mut_slice()[..block_size] };
+                    unsafe { &mut RX_BUFFER.as_mut_slice()[..block_size* 2 * 2] };
                 let dma_config = dma::dma::DmaConfig::default()
                     .priority(dma::config::Priority::High)
                     .memory_increment(true)
@@ -188,7 +188,7 @@ impl Audio {
                 );
 
                 let tx_buffer: &'static mut [u32] =
-                    unsafe { &mut TX_BUFFER.as_mut_slice()[..block_size] };
+                    unsafe { &mut TX_BUFFER.as_mut_slice()[..block_size* 2 * 2] };
                 let dma_config = dma_config
                     .transfer_complete_interrupt(true)
                     .half_transfer_interrupt(true);
@@ -472,7 +472,7 @@ impl Audio {
     fn get_stereo_iter(&mut self) -> Option<StereoIterator> {
         if self.read() {
             return Some(StereoIterator::new(
-                &self.input.buffer[self.input.index..self.max_transfer_size],
+                &self.input.buffer[self.input.index..self.input.index + self.max_transfer_size]
             ));
         }
         None

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -128,14 +128,7 @@ impl From<f32> for S24 {
 
 impl From<S24> for f32 {
     fn from(x: S24) -> f32 {
-        let sign_bit = x.0 & S24_SIGN;
-        let magnitude = x.0 & !S24_SIGN;
-
-        if sign_bit == 0 {
-            magnitude as f32 * S24_TO_F32_SCALE
-        } else {
-            -(magnitude as f32 * S24_TO_F32_SCALE)
-        }
+        ((x.0 << 8) >> 8) as f32 * S24_TO_F32_SCALE
     }
 }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -105,7 +105,7 @@ pub struct SystemResources<'a> {
 #[macro_export]
 macro_rules! system_init {
     ($core:ident, $device:ident, $ccdr:ident) => {
-        libdaisy::system_init!($core, $device, $ccdr, 1024);
+        libdaisy::system_init!($core, $device, $ccdr, libdaisy::audio::BLOCK_SIZE_MAX);
     };
     ($core:ident, $device:ident, $ccdr:ident, $block_size:expr) => {{
         let resources = libdaisy::system::SystemResources {

--- a/src/system.rs
+++ b/src/system.rs
@@ -98,13 +98,16 @@ pub struct SystemResources<'a> {
 
     pub dma1: stm32::DMA1,
     pub dma1_rec: rcc::rec::Dma1,
+
+    pub block_size: usize,
 }
 
 #[macro_export]
 macro_rules! system_init {
-    ($core:ident, $device:ident, $ccdr:ident) => {{
-        // let ccdr = libdaisy::system::System::init_clocks($device.PWR, $device.RCC, &$device.SYSCFG);
-
+    ($core:ident, $device:ident, $ccdr:ident) => {
+        libdaisy::system_init!($core, $device, $ccdr, 1024);
+    };
+    ($core:ident, $device:ident, $ccdr:ident, $block_size:expr) => {{
         let resources = libdaisy::system::SystemResources {
             clocks: &$ccdr.clocks,
             adc1: $device.ADC1,
@@ -144,6 +147,7 @@ macro_rules! system_init {
             gpioi_rec: $ccdr.peripheral.GPIOI,
             dma1: $device.DMA1,
             dma1_rec: $ccdr.peripheral.DMA1,
+            block_size: $block_size
         };
 
         libdaisy::system::System::init(resources)
@@ -348,6 +352,7 @@ impl System {
             resources.clocks,
             version,
             &mut delay,
+            resources.block_size
         );
 
         let (d31, d32) = match version {

--- a/src/system.rs
+++ b/src/system.rs
@@ -147,7 +147,7 @@ macro_rules! system_init {
             gpioi_rec: $ccdr.peripheral.GPIOI,
             dma1: $device.DMA1,
             dma1_rec: $ccdr.peripheral.DMA1,
-            block_size: $block_size
+            block_size: $block_size,
         };
 
         libdaisy::system::System::init(resources)
@@ -352,7 +352,7 @@ impl System {
             resources.clocks,
             version,
             &mut delay,
-            resources.block_size
+            resources.block_size,
         );
 
         let (d31, d32) = match version {


### PR DESCRIPTION
Feature: Allow the library user to set the Block Size.

Changes:
- Add Github Action to ensure examples compile (This currently ignores the usb_midi and sdmmc examples)
- Add extra input to system_init! macro for specifying block size
- Fixed most examples (Builds and flashes without error, actual functionality needs to be tested)
- Updated cargo dependancies 
- Updated Passthru example to use a smaller block size