### PR TITLE
Provided `for_each` audio API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "Hardware Abstraction Layer implementation for Daisy boards"
 keywords = ["cortex-m", "stm32h7xx", "stm32h750", "hal", "daisy"]
 readme = "README.md"
 name = "libdaisy"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT"
 repository = "https://github.com/mtthw-meyer/libdaisy-rust.git"
 documentation = "https://docs.rs/libdaisy"
@@ -14,20 +14,32 @@ exclude = [".gitignore"]
 [dependencies]
 cfg-if = "1"
 cortex-m = "0.7"
-cortex-m-log = { version = "0.8", features = ["itm", "semihosting", "log-integration"], optional = true  }
+cortex-m-log = { version = "0.8", features = [
+  "itm",
+  "semihosting",
+  "log-integration",
+], optional = true }
 cortex-m-rtic = "1"
-cortex-m-semihosting = { version = "0.5", optional = true  }
+cortex-m-semihosting = { version = "0.5", optional = true }
 debouncr = "0.2.2"
-lazy_static = { version = "1.4.0", features = ["spin_no_std"], optional = true  }
+lazy_static = { version = "1.4.0", features = ["spin_no_std"], optional = true }
 log = "0.4"
 micromath = "2"
 panic-halt = "0.2.0"
-panic-itm = { version = "0.4", optional = true  }
+panic-itm = { version = "0.4", optional = true }
 panic-rtt-target = { version = "0.1.3", optional = true }
-panic-semihosting = { version = "0.6", optional = true  }
+panic-semihosting = { version = "0.6", optional = true }
 rtt-target = { version = "0.5.0", optional = true }
 stm32-fmc = "0.3.0"
-stm32h7xx-hal = { version = "0.16.0", features = ["stm32h750v","rt","fmc", "xspi", "sdmmc", "sdmmc-fatfs", "usb_hs"] }
+stm32h7xx-hal = { version = "0.16.0", features = [
+  "stm32h750v",
+  "rt",
+  "fmc",
+  "xspi",
+  "sdmmc",
+  "sdmmc-fatfs",
+  "usb_hs",
+] }
 
 [features]
 default = []
@@ -35,7 +47,12 @@ default = []
 log-itm = ["panic-itm", "lazy_static", "cortex-m-log"]
 log-none = []
 log-rtt = ["rtt-target", "panic-rtt-target"]
-log-semihosting = ["panic-semihosting", "lazy_static", "cortex-m-log", "cortex-m-semihosting"]
+log-semihosting = [
+  "panic-semihosting",
+  "lazy_static",
+  "cortex-m-log",
+  "cortex-m-semihosting",
+]
 
 # this lets you use `cargo fix`!
 #[[bin]]
@@ -44,18 +61,18 @@ log-semihosting = ["panic-semihosting", "lazy_static", "cortex-m-log", "cortex-m
 #bench = false
 
 [profile.dev]
-codegen-units = 1 # better optimizations
-debug = true # symbols are nice and they don't increase the size in flash
+codegen-units = 1   # better optimizations
+debug = true        # symbols are nice and they don't increase the size in flash
 incremental = false
-opt-level = "s" # optimize for binary size
+opt-level = "s"     # optimize for binary size
 
 [profile.release]
 codegen-units = 1 # better optimizations
-debug = true # symbols are nice and they don't increase the size in flash
-lto = true # better optimizations
-opt-level = "s" # optimize for binary size
+debug = true      # symbols are nice and they don't increase the size in flash
+lto = true        # better optimizations
+opt-level = "s"   # optimize for binary size
 
-[dev_dependencies]
+[dev-dependencies]
 embedded-sdmmc = "0.4"
 libm = "0.2"
 num_enum = { version = "0.5", default-features = false }

--- a/examples/passthru.rs
+++ b/examples/passthru.rs
@@ -17,7 +17,6 @@ mod app {
     #[local]
     struct Local {
         audio: audio::Audio,
-        buffer: audio::AudioBuffer,
     }
 
     #[init]
@@ -32,15 +31,12 @@ mod app {
         let ccdr = system::System::init_clocks(device.PWR, device.RCC, &device.SYSCFG);
         let system = libdaisy::system_init!(core, device, ccdr, BLOCK_SIZE);
 
-        let buffer = [(0.0, 0.0); audio::BLOCK_SIZE_MAX];
-
         info!("Startup done!!");
 
         (
             Shared {},
             Local {
                 audio: system.audio,
-                buffer,
             },
             init::Monotonics(),
         )
@@ -56,17 +52,10 @@ mod app {
     }
 
     // Interrupt handler for audio
-    #[task(binds = DMA1_STR1, local = [audio, buffer], priority = 8)]
+    #[task(binds = DMA1_STR1, local = [audio], priority = 8)]
     fn audio_handler(ctx: audio_handler::Context) {
         let audio = ctx.local.audio;
-        let buffer = ctx.local.buffer;
 
-        if audio.get_stereo(buffer) {
-            for (left, right) in &buffer.as_slice()[..BLOCK_SIZE] {
-                let _ = audio.push_stereo((*left, *right));
-            }
-        } else {
-            info!("Error reading data!");
-        }
+        audio.for_each(|left, right| (left, right));
     }
 }

--- a/examples/usb_midi.rs
+++ b/examples/usb_midi.rs
@@ -56,14 +56,6 @@ mod app {
         let _ = ccdr.clocks.hsi48_ck().expect("HSI48 must run");
         ccdr.peripheral.kernel_usb_clk_mux(UsbClkSel::Hsi48);
 
-        /*
-        unsafe {
-            let pwr = &*stm32::PWR::ptr();
-            pwr.cr3.modify(|_, w| w.usbregen().set_bit());
-            while pwr.cr3.read().usb33rdy().bit_is_clear() {}
-        }
-        */
-
         let mut timer2 = device.TIM2.timer(
             MilliSeconds::from_ticks(200).into_rate(),
             ccdr.peripheral.TIM2,
@@ -79,6 +71,7 @@ mod app {
 
         let gpio = gpio::GPIO::init(
             gpioc.pc7,
+            gpiog.pg3,
             Some(gpiob.pb12),
             Some(gpioc.pc11),
             Some(gpioc.pc10),
@@ -110,6 +103,8 @@ mod app {
             Some(gpioa.pa2),
             Some(gpiob.pb14),
             Some(gpiob.pb15),
+            None,
+            None,
         );
 
         let (pin_dm, pin_dp) = { (gpioa.pa11.into_alternate(), gpioa.pa12.into_alternate()) };

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -195,8 +195,8 @@ impl Flash {
     /// - Erasing sets all the bits in the given area to `1`.
     /// - The memory array of the IS25LP064A/032A is organized into uniform 4
     ///   Kbyte sectors or
-    /// 32/64 Kbyte uniform blocks (a block consists of eight/sixteen adjacent
-    /// sectors respectively).
+    ///   32/64 Kbyte uniform blocks (a block consists of eight/sixteen adjacent
+    ///   sectors respectively).
     pub fn erase(&mut self, op: FlashErase) -> NBFlashResult<()> {
         match self.state {
             FlashState::Erasing(e) => {
@@ -266,9 +266,9 @@ impl Flash {
     ///   to a 1.
     /// - The starting byte can be anywhere within the page (256 byte chunk).
     ///   When the end of the
-    /// page is reached, the address will wrap around to the beginning of the
-    /// same page. If the data to be programmed are less than a full page,
-    /// the data of all other bytes on the same page will remain unchanged.
+    ///   page is reached, the address will wrap around to the beginning of the
+    ///   same page. If the data to be programmed are less than a full page,
+    ///   the data of all other bytes on the same page will remain unchanged.
     pub fn program(&mut self, address: u32, data: &[u8]) -> NBFlashResult<()> {
         let prog = |flash: &mut Self, chunk_index: u32| -> NBFlashResult<()> {
             if let Some(chunk) = data.chunks(32).nth(chunk_index as usize) {

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -273,13 +273,8 @@ where
 
     /// Set the brightness of the LED from 0.0 to 1.0.
     pub fn set_brightness(&mut self, value: f32) {
-        let value = if value > 1.0 {
-            1.0
-        } else if value < 0.0 {
-            0.0
-        } else {
-            value
-        };
+        let value = value.clamp(0., 1.);
+
         match self.invert {
             // Bias for slower transitions in the low brightness range
             // TODO configurable?


### PR DESCRIPTION
This PR introduces a more ergonomic, memory-efficient, and performant API for processing audio. Previously, carting around an input buffer was required:

```rs
    #[task(binds = DMA1_STR1, local = [audio, buffer], priority = 8)]
    fn audio_handler(ctx: audio_handler::Context) {
        let audio = ctx.local.audio;
        let buffer = ctx.local.buffer;

        if audio.get_stereo(buffer) {
            for (left, right) in &buffer.as_slice()[..BLOCK_SIZE] {
                let _ = audio.push_stereo((*left, *right));
            }
        } else {
            info!("Error reading data!");
        }
    }
```

This is no longer the case:
```rs
    #[task(binds = DMA1_STR1, local = [audio], priority = 8)]
    fn audio_handler(ctx: audio_handler::Context) {
        let audio = ctx.local.audio;

        audio.for_each(|left, right| (left, right));
    }
```

I figured an error occurring due to misconfigured SAI is unlikely enough to not be worth surfacing. In this case, the closure will simply not be run.

A fallible `try_for_each` method is also provided in situations where fallible processing makes sense.

This PR also introduces a tentative fix for misaligned in and out streams for recent Seed revisions. 