### PR TITLE
Improved bootloader robustness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ cortex-m-log = { version = "0.8", features = [
   "semihosting",
   "log-integration",
 ], optional = true }
-cortex-m-rtic = "1"
 cortex-m-semihosting = { version = "0.5", optional = true }
 debouncr = "0.2.2"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"], optional = true }
@@ -40,6 +39,7 @@ stm32h7xx-hal = { version = "0.16.0", features = [
   "sdmmc-fatfs",
   "usb_hs",
 ] }
+embedded-hal = "0.2"
 
 [features]
 default = []
@@ -73,6 +73,7 @@ lto = true        # better optimizations
 opt-level = "s"   # optimize for binary size
 
 [dev-dependencies]
+cortex-m-rtic = "1"
 embedded-sdmmc = "0.4"
 libm = "0.2"
 num_enum = { version = "0.5", default-features = false }

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,0 +1,53 @@
+//! Simple, cycle-based delay.
+
+use cortex_m::asm::delay as delay_cycles;
+pub use embedded_hal::blocking::delay::{DelayMs, DelayUs};
+
+/// A type that uses CPU cycles as a delay source.
+///
+/// [CycleDelay] is guaranteed to block for
+/// at least as many cycles as requested, but it
+/// makes no claims about accuracy. Servicing
+/// interrupts can make the delay extend much longer.
+///
+/// For accurate timings, use a hardware timer.
+///
+/// Delay methods are provided via `embedded-hal`'s [DelayMs]
+/// and [DelayUs] traits.
+///
+/// ```
+/// use libdaisy::delay::{CycleDelay, DelayMs};
+///
+/// let mut delay = CycleDelay::new();
+/// // You may need to specify the literal's
+/// // type to help Rust resolve the trait.
+/// delay.delay_ms(10u8);
+/// ```
+pub struct CycleDelay;
+
+impl CycleDelay {
+    /// Construct a new [CycleDelay].
+    pub fn new() -> Self {
+        CycleDelay
+    }
+}
+
+macro_rules! impl_delay {
+    ($ty:path) => {
+        impl DelayMs<$ty> for CycleDelay {
+            fn delay_ms(&mut self, ms: $ty) {
+                delay_cycles((ms as u32).saturating_mul(crate::MILICYCLES));
+            }
+        }
+
+        impl DelayUs<$ty> for CycleDelay {
+            fn delay_us(&mut self, us: $ty) {
+                delay_cycles((us as u32).saturating_mul(crate::MICROCYCLES));
+            }
+        }
+    };
+}
+
+impl_delay!(u8);
+impl_delay!(u16);
+impl_delay!(u32);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,10 @@
 #![no_std]
 #![allow(dead_code)]
 
-// #[macro_use(singleton)]
-// extern crate cortex_m;
-
-use cortex_m::asm::delay as delay_cycles;
 use stm32h7xx_hal::time::Hertz;
 
 pub const MILLI: u32 = 1_000;
+pub const MICRO: u32 = 1_000_000;
 pub const AUDIO_FRAME_RATE_HZ: u32 = 1_000;
 pub const AUDIO_BLOCK_SIZE: u16 = 48;
 pub const AUDIO_SAMPLE_RATE: usize = 48_000;
@@ -15,6 +12,7 @@ pub const AUDIO_SAMPLE_HZ: Hertz = Hertz::from_raw(48_000);
 pub const CLOCK_RATE_HZ: Hertz = Hertz::from_raw(480_000_000_u32);
 
 pub const MILICYCLES: u32 = CLOCK_RATE_HZ.raw() / MILLI;
+pub const MICROCYCLES: u32 = CLOCK_RATE_HZ.raw() / MICRO;
 
 pub type FrameTimer = stm32h7xx_hal::timer::Timer<stm32h7xx_hal::stm32::TIM2>;
 
@@ -22,6 +20,7 @@ pub use stm32h7xx_hal as hal;
 
 pub mod audio;
 pub mod bootloader;
+pub mod delay;
 pub mod flash;
 pub mod gpio;
 pub mod hid;
@@ -31,8 +30,3 @@ pub mod prelude;
 pub mod sdmmc;
 pub mod sdram;
 pub mod system;
-
-// Delay for ms, note if interrupts are active delay time will extend
-pub fn delay_ms(ms: u32) {
-    delay_cycles(ms * MILICYCLES);
-}

--- a/src/system.rs
+++ b/src/system.rs
@@ -104,17 +104,14 @@ impl MinimalSystem {
     }
 
     pub fn new(resources: SystemResources) -> Self {
-        let mut delay = Delay::new(resources.syst, *resources.clocks);
+        let delay = Delay::new(resources.syst, *resources.clocks);
 
         let gpioa = resources.gpioa.split(resources.gpioa_rec);
         let gpiob = resources.gpiob.split(resources.gpiob_rec);
         let gpioc = resources.gpioc.split(resources.gpioc_rec);
         let gpiod = resources.gpiod.split(resources.gpiod_rec);
-        let gpioe = resources.gpioe.split(resources.gpioe_rec);
         let gpiof = resources.gpiof.split(resources.gpiof_rec);
         let gpiog = resources.gpiog.split(resources.gpiog_rec);
-        let gpioh = resources.gpioh.split(resources.gpioh_rec);
-        let gpioi = resources.gpioi.split(resources.gpioi_rec);
 
         // Set up GPIOs
         let gpio = crate::gpio::GPIO::init(


### PR DESCRIPTION
This PR improves the robustness of the bootloader support code.

It also removed the simple `delay_ms` function in favor of a ZST that implements the delay traits from `embedded-hal`.