### PR TITLE
Device PCA9555

### DIFF
--- a/src/devices/expander_pca9555.rs
+++ b/src/devices/expander_pca9555.rs
@@ -31,8 +31,10 @@ pub type WriteReadError<W: Write + WriteRead> =
 
 impl Pca9555 {
     pub fn new<W: Write + WriteRead>(address: u8, bus: &mut W) -> Result<Self, WriteReadError<W>> {
+        let base_address = 0x20;
+        let dev_addr = base_address + address;
         let dev = Pca9555 {
-            address,
+            address: dev_addr,
             states: Default::default(),
         };
 
@@ -43,12 +45,13 @@ impl Pca9555 {
         // So for our initial implementation.. no config is necessary
 
         // Fill internal data with current states on hardware.
-        self.update();
+        dev.update();
 
-        // Return
         Ok(dev)
     }
 
+    /// Polls the device, reading both of it's input registers to fill the
+    /// internal state data
     pub fn update<W: Write + WriteRead>(&mut self, bus: &mut W) -> Result<(), WriteReadError<W>> {
         // Register pairs flip automatically after reads.
         // So we can basically just send the `InputPort0` command,
@@ -61,6 +64,12 @@ impl Pca9555 {
             self.states[i] = (raw_union & (1 << i)) != 0;
         }
         Ok(())
+    }
+
+    /// Returns the current state recorded for a particular pin
+    pub fn get_state(self, index: u16) -> bool {
+        let idx = index.clamp(0, 16);
+        self.states[idx]
     }
 
     fn write<W: Write + WriteRead>(

--- a/src/devices/expander_pca9555.rs
+++ b/src/devices/expander_pca9555.rs
@@ -1,0 +1,119 @@
+use crate::hal;
+use hal::i2c::I2c;
+use hal::prelude::*;
+use stm32h7xx_hal::prelude::{
+    _embedded_hal_blocking_i2c_Write as Write, _embedded_hal_blocking_i2c_WriteRead as WriteRead,
+};
+
+/// Data corresponding to a single PCA9555 I/O Expander
+///
+/// In the future we can add:
+/// - chained-device support (similar to pca9685)
+/// - output configuration
+/// - INT pin support for non-polling behavior
+///
+/// For now this is a minimal driver for providing access
+/// to 16 additional inptus.
+pub struct Pca9555 {
+    address: u8,
+    states: [bool; 16],
+}
+
+#[derive(Debug)]
+pub enum I2cError<W, WR> {
+    Write(W),
+    WriteRead(WR),
+}
+
+#[expect(type_alias_bounds)]
+pub type WriteReadError<W: Write + WriteRead> =
+    I2cError<<W as Write>::Error, <W as WriteRead>::Error>;
+
+impl Pca9555 {
+    pub fn new<W: Write + WriteRead>(address: u8, bus: &mut W) -> Result<Self, WriteReadError<W>> {
+        let dev = Pca9555 {
+            address,
+            states: Default::default(),
+        };
+
+        // Configuration
+        // Default config appears to be:
+        // configuration = input
+        // polarity = not-inverted
+        // So for our initial implementation.. no config is necessary
+
+        // Fill internal data with current states on hardware.
+        self.update();
+
+        // Return
+        Ok(dev)
+    }
+
+    pub fn update<W: Write + WriteRead>(&mut self, bus: &mut W) -> Result<(), WriteReadError<W>> {
+        // Register pairs flip automatically after reads.
+        // So we can basically just send the `InputPort0` command,
+        // and read two data bytes back every time we want new data
+        let mut raw_states = [u8; 2];
+        self.read(bus, Register::InputPort0, raw_states)?;
+
+        for i in 0..16 {
+            let raw_union: u16 = ((raw_states[0] as u16) | ((raw_states as u16) << 8));
+            self.states[i] = (raw_union & (1 << i)) != 0;
+        }
+        Ok(())
+    }
+
+    fn write<W: Write + WriteRead>(
+        &self,
+        bus: &mut W,
+        register: Register,
+        data: u8,
+    ) -> Result<(), WriteReadError<W>> {
+        self.write_raw(bus, register as u8, data)
+    }
+
+    fn write_raw<W: Write + WriteRead>(
+        &self,
+        bus: &mut W,
+        register: u8,
+        data: u8,
+    ) -> Result<(), WriteReadError<W>> {
+        // This is probably not what we need
+        bus.write(self.address, &[register, data])
+            .map_err(I2cError::Write)?;
+
+        Ok(())
+    }
+
+    fn read<W: Write + WriteRead>(
+        &self,
+        bus: &mut W,
+        register: Register,
+        buffer: &mut [u8],
+    ) -> Result<(), WriteReadError<W>> {
+        self.read_raw(bus, register as u8, buffer)
+    }
+
+    fn read_raw<W: Write + WriteRead>(
+        &self,
+        bus: &mut W,
+        register: u8,
+        buffer: &mut [u8],
+    ) -> Result<(), WriteReadError<W>> {
+        bus.write_read(self.address, &[register], buffer)
+            .map_err(I2cError::WriteRead)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+enum Register {
+    InputPort0 = 0x00,
+    InputPort1 = 0x01,
+    OutputPort0 = 0x02,
+    OutputPort1 = 0x03,
+    PolarityInversion0 = 0x04,
+    PolarityInversion1 = 0x05,
+    ConfigurationPort0 = 0x06,
+    ConfigurationPort1 = 0x07,
+}

--- a/src/devices/expander_pca9555.rs
+++ b/src/devices/expander_pca9555.rs
@@ -2,7 +2,8 @@ use crate::hal;
 use hal::i2c::I2c;
 use hal::prelude::*;
 use stm32h7xx_hal::prelude::{
-    _embedded_hal_blocking_i2c_Write as Write, _embedded_hal_blocking_i2c_WriteRead as WriteRead,
+    _embedded_hal_blocking_i2c_Read as Read, _embedded_hal_blocking_i2c_Write as Write,
+    _embedded_hal_blocking_i2c_WriteRead as WriteRead,
 };
 
 /// Data corresponding to a single PCA9555 I/O Expander
@@ -14,7 +15,8 @@ use stm32h7xx_hal::prelude::{
 ///
 /// For now this is a minimal driver for providing access
 /// to 16 additional inptus.
-pub struct Pca9555 {
+pub struct Pca9555<I2CN> {
+    i2c: I2c<I2CN>,
     address: u8,
     states: [bool; 16],
 }
@@ -29,11 +31,15 @@ pub enum I2cError<W, WR> {
 pub type WriteReadError<W: Write + WriteRead> =
     I2cError<<W as Write>::Error, <W as WriteRead>::Error>;
 
-impl Pca9555 {
-    pub fn new<W: Write + WriteRead>(address: u8, bus: &mut W) -> Result<Self, WriteReadError<W>> {
+impl<I2CN> Pca9555<I2CN>
+where
+    I2c<I2CN>: Write + WriteRead + Read,
+{
+    pub fn new(address: u8, mut bus: I2c<I2CN>) -> Self {
         let base_address = 0x20;
-        let dev_addr = base_address + address;
-        let dev = Pca9555 {
+        let dev_addr = base_address | (address & 0x07);
+        let mut dev = Pca9555 {
+            i2c: bus,
             address: dev_addr,
             states: Default::default(),
         };
@@ -44,73 +50,44 @@ impl Pca9555 {
         // polarity = not-inverted
         // So for our initial implementation.. no config is necessary
 
-        // Fill internal data with current states on hardware.
-        dev.update();
+        // Any attempts to write here will cause an infinite loop during if device is not
+        // present and serial callback hasn't been started. So maybe we don't do this here yet.
 
-        Ok(dev)
+        // This was here to test why device wasn't sending ACK (but it wasn't on the PCB ...)
+        // Will remove these comments, and finish driver once I have appropriate HW
+        // crate::delay::CycleDelay::new().delay_ms(30u8);
+        // let _ = dev
+        //     .i2c
+        //     .write(dev.address, &[Register::ConfigurationPort0 as u8, 0xff]);
+
+        // Fill internal data with current states on hardware.
+        // dev.update();
+
+        dev
     }
 
     /// Polls the device, reading both of it's input registers to fill the
     /// internal state data
-    pub fn update<W: Write + WriteRead>(&mut self, bus: &mut W) -> Result<(), WriteReadError<W>> {
+    // pub fn update(&mut self) -> Result<(), WriteReadError<W>> {
+    pub fn update(&mut self) {
         // Register pairs flip automatically after reads.
         // So we can basically just send the `InputPort0` command,
         // and read two data bytes back every time we want new data
-        let mut raw_states = [u8; 2];
-        self.read(bus, Register::InputPort0, raw_states)?;
+        let mut raw_states = [0u8; 2];
+        let _ = self
+            .i2c
+            .write_read(self.address, &[Register::InputPort0 as u8], &mut raw_states);
 
+        let raw_union: u16 = (raw_states[0] as u16) | ((raw_states[1] as u16) << 8);
         for i in 0..16 {
-            let raw_union: u16 = ((raw_states[0] as u16) | ((raw_states as u16) << 8));
             self.states[i] = (raw_union & (1 << i)) != 0;
         }
-        Ok(())
     }
 
     /// Returns the current state recorded for a particular pin
-    pub fn get_state(self, index: u16) -> bool {
-        let idx = index.clamp(0, 16);
+    pub fn get_state(&self, index: usize) -> bool {
+        let idx = index.min(15);
         self.states[idx]
-    }
-
-    fn write<W: Write + WriteRead>(
-        &self,
-        bus: &mut W,
-        register: Register,
-        data: u8,
-    ) -> Result<(), WriteReadError<W>> {
-        self.write_raw(bus, register as u8, data)
-    }
-
-    fn write_raw<W: Write + WriteRead>(
-        &self,
-        bus: &mut W,
-        register: u8,
-        data: u8,
-    ) -> Result<(), WriteReadError<W>> {
-        // This is probably not what we need
-        bus.write(self.address, &[register, data])
-            .map_err(I2cError::Write)?;
-
-        Ok(())
-    }
-
-    fn read<W: Write + WriteRead>(
-        &self,
-        bus: &mut W,
-        register: Register,
-        buffer: &mut [u8],
-    ) -> Result<(), WriteReadError<W>> {
-        self.read_raw(bus, register as u8, buffer)
-    }
-
-    fn read_raw<W: Write + WriteRead>(
-        &self,
-        bus: &mut W,
-        register: u8,
-        buffer: &mut [u8],
-    ) -> Result<(), WriteReadError<W>> {
-        bus.write_read(self.address, &[register], buffer)
-            .map_err(I2cError::WriteRead)
     }
 }
 

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -1,4 +1,5 @@
 pub mod encoder;
+pub mod expander_pca9555;
 pub mod led_driver_pca9685;
 pub mod mpr121;
 pub mod multiplexer;


### PR DESCRIPTION
This _will_ be required for something upcoming, but we don't have the hardware to test it quite yet.

It looks like it will work fine, though there may be some initial config reset, etc. we want to do during the constructor to ensure any config changes are cleared properly once more features are added (since the device only resets with a POR, and its unlikely that the device power will be a commonly accessible control separate from the daisy on most hardware).